### PR TITLE
Correccion campo subcuenta linea

### DIFF
--- a/Lib/AsientoPredefinidoGenerator.php
+++ b/Lib/AsientoPredefinidoGenerator.php
@@ -225,7 +225,7 @@ class AsientoPredefinidoGenerator
             Where::eq('codsubcuenta', $valorFinal) // transforma el punto en ceros
         ];
         if (false === $subcuenta->loadFromCode('', $where)) {
-            Tools::log()->warning('subaccount-not-found', ['%subAccountCode%' => $valorFinal]);
+            Tools::log()->warning('subaccount-not-found', ['%code%' => $valorFinal]);
         }
         return $subcuenta;
     }

--- a/Model/AsientoPredefinidoLinea.php
+++ b/Model/AsientoPredefinidoLinea.php
@@ -108,6 +108,9 @@ class AsientoPredefinidoLinea extends ModelClass
         // reemplazamos la coma por punto
         $cantidad = str_replace(',', '.', $cantidad);
 
+        // convertimos las letras de las variables a mayúsculas
+        $cantidad = strtoupper($cantidad);
+
         // quitamos de $cantidad lo que no sean números, letras mayúsculas, punto, signo menos, signo más, signo *, signo / y espacios
         $aceptados = preg_replace('/[^A-Z0-9\.\-\+\*\/\s]/', '', $cantidad);
 


### PR DESCRIPTION
https://facturascripts.com/roadmap/4970
- Se actualiza el mensaje de advertencia en AsientoPredefinidoGenerator.php para usar '%code%' en lugar de '%subAccountCode%'.
- Se añade conversión a mayúsculas de la variable $cantidad en AsientoPredefinidoLinea.php antes de aplicar la limpieza de caracteres.